### PR TITLE
Fixed issue where abruptly ending 'listen' would not free the port. 

### DIFF
--- a/+gadgetron/+external/+readers/read_config_file.m
+++ b/+gadgetron/+external/+readers/read_config_file.m
@@ -1,0 +1,15 @@
+function config = read_config_file(socket)
+    filename = read(socket, 1024, 'int8');
+
+    filename = filename(filename ~= 0);
+    filename = char(filename');
+    
+    warning( ...
+        "gadgetron:external:config_filename", ...
+        "[Unsupported] Client referenced config file by name: %s", ...
+        filename ...
+    );
+    
+    config = filename;
+end
+

--- a/+gadgetron/+external/Connection.m
+++ b/+gadgetron/+external/Connection.m
@@ -116,7 +116,7 @@ classdef Connection < handle
 
         function config = read_config(self) 
             [config, mid] = self.next();
-            assert(mid == gadgetron.Constants.CONFIG);
+            assert(mid == gadgetron.Constants.CONFIG || mid == gadgetron.Constants.FILENAME);
         end
         
         function header = read_header(self)
@@ -131,6 +131,7 @@ classdef Connection < handle
             % Maps do not support a wide range of key types. We're forced
             % to use uint32, as uint16 is not supported.
             readers = containers.Map('KeyType', 'uint32', 'ValueType', 'any');
+            readers(uint32(gadgetron.Constants.FILENAME))    = @gadgetron.external.readers.read_config_file;
             readers(uint32(gadgetron.Constants.CONFIG))      = @gadgetron.external.readers.read_config;
             readers(uint32(gadgetron.Constants.HEADER))      = @gadgetron.external.readers.read_header;
             readers(uint32(gadgetron.Constants.ACQUISITION)) = @gadgetron.external.readers.read_acquisition;

--- a/+gadgetron/+external/listen.m
+++ b/+gadgetron/+external/listen.m
@@ -17,12 +17,12 @@ function listen(port, handler, varargin)
     %
     % For more information, see <a href="https://github.com/gadgetron/gadgetron/wiki">the Gadgetron Wiki</a>. 
 
-    fprintf("Starting external MATLAB module '%s' in state: [PASSIVE]\n", func2str(handler))
+    fprintf("Starting ISMRMRD server with handler '%s' in state: [PASSIVE]\n", func2str(handler))
     fprintf("Waiting for connection from client on port: %d\n", port)
     
     sock = socket.listen(port);
     connection = gadgetron.external.Connection(sock);
-   
+    
     handler(connection, varargin{:});
 end
 

--- a/+socket/listen.m
+++ b/+socket/listen.m
@@ -3,7 +3,9 @@
 function sock = listen(port)
     server = java.net.ServerSocket(port);
     server.setReuseAddress(true);
-    server.setSoTimeout(1000); 
+    server.setSoTimeout(1000);
+    
+    cleanup = onCleanup(@() server.close());
 
     % Accept would block forever in previous versions, leaving Matlab
     % unresponsive (process was blocked, so Ctrl+C was ignored). 

--- a/gadgetron.prj
+++ b/gadgetron.prj
@@ -8,7 +8,7 @@
     <param.description>This Gadgetron interface is based on ISMRMRD Datatypes, fascilitating direct communication with Gadgetron, or other ISMRMRD-based applications.
 NOTE: Requires Gadgetron 4.1 or newer; currently considered BLEEDING EDGE; the interface is still likely to change.</param.description>
     <param.screenshot />
-    <param.version>2.0.6</param.version>
+    <param.version>2.0.7</param.version>
     <param.output>${PROJECT_ROOT}/gadgetron.mltbx</param.output>
     <param.products.name />
     <param.products.id />
@@ -126,7 +126,7 @@ NOTE: Requires Gadgetron 4.1 or newer; currently considered BLEEDING EDGE; the i
       <vista>false</vista>
       <linux>true</linux>
       <solaris>false</solaris>
-      <osver>5.5.8-200.fc31.x86_64</osver>
+      <osver>5.5.9-200.fc31.x86_64</osver>
       <os32>false</os32>
       <os64>true</os64>
       <arch>glnxa64</arch>


### PR DESCRIPTION
Fixed 'Port already in use' issue. Also added handler for config filename - a warning is now produced (in stead of an error).