### PR TITLE
Fix for reading large (over 2 GiB) buffers from the socket.

### DIFF
--- a/+socket/Socket.m
+++ b/+socket/Socket.m
@@ -21,22 +21,19 @@ classdef Socket < handle
         end
         
         function out = read(self, n, type)
-            total_bytes_to_read = n * self.sizes(type);
-
+            total_bytes_to_read = double(n) * self.sizes(type);
+                        
             % Java can only have around 2^31 elements in an array. If we're
             % reading something larger, we need to read it in chunks. 
-            
-            array_size_limit = intmax('int32') - 8; % Java uses a few words for array header stuff.
+            array_size_limit = double(intmax('int32')) - 8; % Java uses a few words for array header stuff.            
             bytes = zeros(total_bytes_to_read, 1, 'int8');
+                        
             current_index = 0;
             
             while current_index < total_bytes_to_read
-                nbytes = min(int32(total_bytes_to_read - current_index), array_size_limit);
-                
+                nbytes = min(total_bytes_to_read - current_index, array_size_limit);
                 next_index = current_index + nbytes;
-                
-                bytes(current_index + 1:next_index) = read(self.sock, nbytes);
-               
+                bytes(current_index + 1:next_index) = read(self.sock, int32(nbytes));
                 current_index = next_index;
             end
             


### PR DESCRIPTION
Fixed issue where `current_index` acquired new type (int32) after the first iteration, causing indexing failures. 

Indexing is now always done using doubles, as the integer part is large enough, and doubles appear to be faster than integer types when indexing in Matlab. 
