### PR TITLE
add unit test passthrough

### DIFF
--- a/+gadgetron/+integration_test/ut_passthrough.m
+++ b/+gadgetron/+integration_test/ut_passthrough.m
@@ -1,0 +1,13 @@
+function ut_passthrough(connection)
+disp('ut_passthrough')
+
+    function send_data(connection)
+        disp("Sending data to client.");
+        connection.send(connection.next());
+    end
+
+next = @() send_data(connection);
+
+tic, gadgetron.consume(next); toc
+end
+


### PR DESCRIPTION
This pull request is linked with this commit for gadgetron (on my fork) -> https://github.com/aTrotier/gadgetron/commit/38d7e0e1e26d0e485b60128417cfeca907ccbee9

It implements an integration test with a passthrough whatever the data type is. However, only 3 writers are working for now :
* Acquisition
* Image
* Waveform*

\* the waveform integration test (under gadgetron) is not implemented. I need to find a dataset and XML which use that part.
