### PR TITLE
Updated examples to set image metadata more correctly.

### DIFF
--- a/+gadgetron/+examples/+steps/create_ismrmrd_image.m
+++ b/+gadgetron/+examples/+steps/create_ismrmrd_image.m
@@ -1,8 +1,13 @@
-function next = create_ismrmrd_image(input)
+function next = create_ismrmrd_image(input, header)
 
-    function image = create_image(image)
+    function image = create_image(image)        
         image = gadgetron.types.Image.from_data(image.data, image.reference);
         image.header.image_type = gadgetron.types.Image.MAGNITUDE;
+        image.header.field_of_view = [ ...
+            header.encoding.reconSpace.fieldOfView_mm.x, ...
+            header.encoding.reconSpace.fieldOfView_mm.y, ...
+            header.encoding.reconSpace.fieldOfView_mm.z  ...
+        ];
     end
 
     next = @() create_image(input());

--- a/+gadgetron/+examples/+steps/set_image_index.m
+++ b/+gadgetron/+examples/+steps/set_image_index.m
@@ -1,0 +1,20 @@
+function next = set_image_index(input)
+
+    indices = containers.Map('KeyType', 'uint32', 'ValueType', 'uint32');
+    
+    function index = produce_index(series)
+        if indices.isKey(series)        
+            index = indices(series) + 1;
+        else
+            index = 1;
+        end
+        
+        indices(series) = index;
+    end
+    
+    function image = set_image_index(image)
+        image.header.image_index = produce_index(image.header.image_series_index);
+    end
+
+    next = @() set_image_index(input());
+end

--- a/+gadgetron/+examples/bucket_recon.m
+++ b/+gadgetron/+examples/bucket_recon.m
@@ -5,7 +5,8 @@ function bucket_recon(connection)
     next = gadgetron.examples.steps.create_slice_from_bucket(@connection.next, connection.header);        
     next = gadgetron.examples.steps.basic_reconstruction(next);
     next = gadgetron.examples.steps.combine_channels(next);
-    next = gadgetron.examples.steps.create_ismrmrd_image(next);
+    next = gadgetron.examples.steps.create_ismrmrd_image(next, connection.header);
+    next = gadgetron.examples.steps.set_image_index(next);
     next = gadgetron.examples.steps.send_image_to_client(next, connection);
     
     tic, gadgetron.consume(next); toc

--- a/+gadgetron/+examples/buffer_recon.m
+++ b/+gadgetron/+examples/buffer_recon.m
@@ -3,7 +3,8 @@ function buffer_recon(connection) % 'Buffer' is a colloquial name for Recon Data
     next = gadgetron.examples.steps.create_slice_from_recon_data(@connection.next);        
     next = gadgetron.examples.steps.basic_reconstruction(next);
     next = gadgetron.examples.steps.combine_channels(next);
-    next = gadgetron.examples.steps.create_ismrmrd_image(next);
+    next = gadgetron.examples.steps.create_ismrmrd_image(next, connection.header);
+    next = gadgetron.examples.steps.set_image_index(next);
     next = gadgetron.examples.steps.send_image_to_client(next, connection);
 
     tic; gadgetron.consume(next); toc

--- a/+gadgetron/+examples/simple_recon.m
+++ b/+gadgetron/+examples/simple_recon.m
@@ -8,7 +8,8 @@ function simple_recon(connection)
     next = gadgetron.examples.steps.accumulate_slice(next, connection.header);
     next = gadgetron.examples.steps.basic_reconstruction(next);
     next = gadgetron.examples.steps.combine_channels(next);
-    next = gadgetron.examples.steps.create_ismrmrd_image(next);
+    next = gadgetron.examples.steps.create_ismrmrd_image(next, connection.header);
+    next = gadgetron.examples.steps.set_image_index(next);
     next = gadgetron.examples.steps.send_image_to_client(next, connection);
     
     connection.filter('gadgetron.types.Acquisition')

--- a/+gadgetron/+types/private/create_image_header.m
+++ b/+gadgetron/+types/private/create_image_header.m
@@ -13,12 +13,12 @@ function header = create_image_header(data, reference)
     header.slice_dir                = reference.slice_dir;
     header.patient_table_position   = reference.patient_table_position;
     
-    header.average                  = 0;
+    header.average                  = reference.average;
     header.slice                    = reference.slice;
-    header.contrast                 = 0;
-    header.phase                    = 0;
-    header.repetition               = 0;
-    header.set                      = 0;
+    header.contrast                 = reference.contrast;
+    header.phase                    = reference.phase;
+    header.repetition               = reference.repetition;
+    header.set                      = reference.set;
     
     header.acquisition_time_stamp   = reference.acquisition_time_stamp;
     header.physiology_time_stamp    = reference.physiology_time_stamp;

--- a/gadgetron.prj
+++ b/gadgetron.prj
@@ -8,7 +8,7 @@
     <param.description>This Gadgetron interface is based on ISMRMRD Datatypes, fascilitating direct communication with Gadgetron, or other ISMRMRD-based applications.
 NOTE: Requires Gadgetron 4.1 or newer.</param.description>
     <param.screenshot>${PROJECT_ROOT}/gadgetron-logo.png</param.screenshot>
-    <param.version>2.1.0</param.version>
+    <param.version>2.1.1</param.version>
     <param.output>${PROJECT_ROOT}/gadgetron.mltbx</param.output>
     <param.products.name />
     <param.products.id />
@@ -124,7 +124,7 @@ NOTE: Requires Gadgetron 4.1 or newer.</param.description>
       <vista>false</vista>
       <linux>true</linux>
       <solaris>false</solaris>
-      <osver>5.12.10-200.fc33.x86_64</osver>
+      <osver>5.13.14-100.fc33.x86_64</osver>
       <os32>false</os32>
       <os64>true</os64>
       <arch>glnxa64</arch>


### PR DESCRIPTION
Matlab examples now set image field of view and image indices. 
Image idx counters not also copied from reference acquisition. 